### PR TITLE
Warnings for installer if .NET 8 is missing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
         <XDotnetVersion>net8.0</XDotnetVersion>
+        <XInstallerRuntimeVersionRequirement>8.0.0</XInstallerRuntimeVersionRequirement>
         <XNetPackageVersion>8.0.0</XNetPackageVersion>
         <MauiVersion>8.0.3</MauiVersion>
     </PropertyGroup>

--- a/deploy/createMSIFast.ps1
+++ b/deploy/createMSIFast.ps1
@@ -7,13 +7,28 @@ param (
     [string]$Version="3.0.0",
     
     [Parameter(HelpMessage="Whether or not to open browser at first msi match or not")]
-    [bool]$OpenExplorer=$true
+    [bool]$OpenExplorer=$true,
+    
+    [Parameter(HelpMessage="Start MSI file")]
+    [bool]$OpenMsi=$false
 )
 
 $scriptPath = Resolve-Path "$PSScriptRoot\createMsi.ps1"
 
-switch($Configuration){
-    "Fresh" { & "$scriptPath" -DeleteArtifacts $true -SkipPublish $false -SkipHarvesting $false -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
-    "RecycleBoth" { & "$scriptPath" -DeleteArtifacts $false -SkipPublish $true -SkipHarvesting $true -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
-    "JustHarvest" { & "$scriptPath" -DeleteArtifacts $false -SkipPublish $true -SkipHarvesting $false -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
+if($OpenMsi -eq $true){
+    switch($Configuration){
+        "Fresh" { $r = & "$scriptPath" -DeleteArtifacts $true -SkipPublish $false -SkipHarvesting $false -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
+        "RecycleBoth" { $r = & "$scriptPath" -DeleteArtifacts $false -SkipPublish $true -SkipHarvesting $true -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
+        "JustHarvest" { $r = & "$scriptPath" -DeleteArtifacts $false -SkipPublish $true -SkipHarvesting $false -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
+    }
+
+    & $r.MsiPath    
+}
+else
+{
+    switch($Configuration){
+        "Fresh" { & "$scriptPath" -DeleteArtifacts $true -SkipPublish $false -SkipHarvesting $false -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
+        "RecycleBoth" { & "$scriptPath" -DeleteArtifacts $false -SkipPublish $true -SkipHarvesting $true -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
+        "JustHarvest" { & "$scriptPath" -DeleteArtifacts $false -SkipPublish $true -SkipHarvesting $false -OpenExplorer $OpenExplorer -ProductVersion "$Version" }
+    }    
 }

--- a/installer/Amusoft.PCR.Installer/Amusoft.PCR.Installer.wixproj
+++ b/installer/Amusoft.PCR.Installer/Amusoft.PCR.Installer.wixproj
@@ -13,6 +13,7 @@
     <ProductComponentsRef>true</ProductComponentsRef>
     <DefineConstants>
       $(DefineConstants);
+      XInstallerRuntimeVersionRequirement=$(XInstallerRuntimeVersionRequirement);
       ArtifactsPathWeb=$(SolutionDir)..\artifacts\msi\web\;
       ArtifactsPathWinInt=$(SolutionDir)..\artifacts\msi\win-integration\;
       ArtifactsPathUIWindows=$(SolutionDir)..\artifacts\msi\ui-windows\;
@@ -39,6 +40,7 @@
     <PackageReference Include="WixToolset.Firewall.wixext" Version="4.0.3" />
     <PackageReference Include="WixToolset.UI.wixext" Version="4.0.3" />
     <PackageReference Include="WixToolset.Util.wixext" Version="4.0.3" />
+    <PackageReference Include="WixToolset.Netfx.wixext" Version="4.0.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/installer/Amusoft.PCR.Installer/Package.de-de.wxl
+++ b/installer/Amusoft.PCR.Installer/Package.de-de.wxl
@@ -5,5 +5,6 @@
 	<String Id="FwExServer" Value="Amusoft PC Remote 3 Command Server der verwendet wird um Kommandos an den Agenten weiterzuleiten" />
 	<String Id="FwExDiscovery" Value="Amusoft PC Remote 3 Client Discovery wird benutzt um Klienten für Endgeräte finden zu können" />
 	<String Id="ServiceConfigReboot" Value="PC Remote 3 benötigt einen Neustart" />
+	<String Id="InstallerDotNetRuntimeMissing" Value="Diese Anwendung benötigt die .NET 8 (Server, Desktop und Core) Laufzeitumgebung, verfügbar unter: https://dotnet.microsoft.com/en-us/download/dotnet/8.0." />
 
 </WixLocalization>

--- a/installer/Amusoft.PCR.Installer/Package.en-us.wxl
+++ b/installer/Amusoft.PCR.Installer/Package.en-us.wxl
@@ -5,5 +5,6 @@
 	<String Id="FwExServer" Value="Amusoft PC Remote 3 Command Server used to delegate commands to the windows agent" />
 	<String Id="FwExDiscovery" Value="Amusoft PC Remote 3 Client Discovery used for clients to discover the command server" />
 	<String Id="ServiceConfigReboot" Value="PC Remote 3 requires a reboot" />
+	<String Id="InstallerDotNetRuntimeMissing" Value="This application requires Server, Desktop and Core .NET 8 runtimes, available at https://dotnet.microsoft.com/en-us/download/dotnet/8.0." />
 
 </WixLocalization>

--- a/installer/Amusoft.PCR.Installer/Package.wxs
+++ b/installer/Amusoft.PCR.Installer/Package.wxs
@@ -1,5 +1,6 @@
 ﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
 	 xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"
+	 xmlns:netfx="http://wixtoolset.org/schemas/v4/wxs/netfx"
 	 xmlns:firewall="http://wixtoolset.org/schemas/v4/wxs/firewall"
 	 xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
 		
@@ -9,6 +10,29 @@
 			 Version="$(var.ProductVersion)" 
 			 UpgradeCode="de4ddeff-2caf-4c46-b9ff-52a37586069a">
 		<MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+		
+		<netfx:DotNetCompatibilityCheck
+						Property="CHECKINSTALLRUNTIME64DESKTOP"
+						RollForward="major"
+						RuntimeType="desktop"
+						Platform="x64"
+						Version="$(var.XInstallerRuntimeVersionRequirement)"/>
+		<netfx:DotNetCompatibilityCheck
+						Property="CHECKINSTALLRUNTIME64CORE"
+						RollForward="major"
+						RuntimeType="core"
+						Platform="x64"
+						Version="$(var.XInstallerRuntimeVersionRequirement)"/>
+		<netfx:DotNetCompatibilityCheck
+						Property="CHECKINSTALLRUNTIME64SERVER"
+						RollForward="major"
+						RuntimeType="aspnet"
+						Platform="x64"
+						Version="$(var.XInstallerRuntimeVersionRequirement)"/>
+		
+		<Launch
+						Message="!(loc.InstallerDotNetRuntimeMissing)"
+						Condition="(CHECKINSTALLRUNTIME64DESKTOP=0) AND (CHECKINSTALLRUNTIME64CORE=0) AND (CHECKINSTALLRUNTIME64SERVER=0)"/>
 		
 		<!-- disable *.cab files-->
 		<MediaTemplate EmbedCab="yes" />


### PR DESCRIPTION
This PR deals with #23. Having .NET automatically installed when .NET is missing requires a bundle chain to work. There are more important things, so warnings will do for now.